### PR TITLE
add GULP_MULTI_MAX_PROC environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ gulp.task('multi', function(cb) {
 
 Run task in multiple processes is not always good for performance because spawn a different node processes is slow. It also depends on how long time it takes to require your `gulpfile`.
 Keep in mind that you can pass a ratio (i.e `0.5`) as a third parameter to `gulpMultiProcess` fn in order to get optimal preformance. This will launch one process per core (adjusted by the ratio), and if there will be more of them than the number of usable cores on your machine it will put others into queue. When one process will finish its operation, the next one will be on launched.
+The number of sub process can be specified using an environment variable called GULP_MULTI_MAX_PROC - otherwise os.cpus() is used to set the number of sub process.  Which ever value is used it is scaled using the ratio.

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ gulp.task('multi', function(cb) {
 
 Run task in multiple processes is not always good for performance because spawn a different node processes is slow. It also depends on how long time it takes to require your `gulpfile`.
 Keep in mind that you can pass a ratio (i.e `0.5`) as a third parameter to `gulpMultiProcess` fn in order to get optimal preformance. This will launch one process per core (adjusted by the ratio), and if there will be more of them than the number of usable cores on your machine it will put others into queue. When one process will finish its operation, the next one will be on launched.
-The number of sub process can be specified using an environment variable called GULP_MULTI_MAX_PROC - otherwise os.cpus() is used to set the number of sub process.  Which ever value is used it is scaled using the ratio.
+The number of sub process can be specified using an environment variable called GULP_MULTI_MAX_PROC - otherwise os.cpus() is used to set the number of sub processes.  Whichever value is used it is scaled using the ratio.

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ var gulpMultiProcess = function(tasks, cb, cpuRatio, failOnFirstError) {
     });
     tasks.forEach(each);
   } else {
-    cpusNumber = Math.floor(require('os').cpus().length * cpuRatio);
+    cpusNumber = Math.floor( (process.env.GULP_MULTI_MAX_PROC ? 
+      process.env.GULP_MULTI_MAX_PROC : require('os').cpus().length) * cpuRatio);
     q = require('async.queue');
     q = q(function (taskName, callback) {
       createWorker(


### PR DESCRIPTION
Added an environment variable that lets you set the maximum sub processes for gulp-multi-proc.  For environments like kubernetes where os.cpus() implies the cpu count of the node and not the pod allocation.